### PR TITLE
Fix incorrect filename level.obj, update Kore to fix gamepad issue on Linux.

### DIFF
--- a/Sources/Exercise.cpp
+++ b/Sources/Exercise.cpp
@@ -224,7 +224,7 @@ namespace {
 		pvLocation = pipeline->getConstantLocation("PV");
 		mLocation = pipeline->getConstantLocation("M");
 
-		objects[0] = new MeshObject("Level/Level.obj", "Level/basicTiles6x6.png", structure);
+		objects[0] = new MeshObject("Level/level.obj", "Level/basicTiles6x6.png", structure);
 		objects[1] = new MeshObject("Level/Level_yellow.obj", "Level/basicTiles3x3yellow.png", structure);
 		objects[2] = new MeshObject("Level/Level_red.obj", "Level/basicTiles3x3red.png", structure);
 


### PR DESCRIPTION
* Fix incorrect filename level.obj #1 (thanks @magcks)
* Update Kore to fix gamepad issue on Linux

Kore `ad42e19` prevents Exercise9 from compiling on Linux.

The following issue is fixed since commit `2185462` "Clean up Linux gamepad code"
```
[ 40%] Building CXX object CMakeFiles/Exercise9.dir/game-technology/Exercise9/Kore/Backends/System/Linux/Sources/Kore/Input/HIDManager.cpp.o
game-technology/Exercise9/Kore/Backends/System/Linux/Sources/Kore/Input/HIDManager.cpp: In destructor ‘Kore::HIDManager::~HIDManager()’:
game-technology/Exercise9/Kore/Backends/System/Linux/Sources/Kore/Input/HIDManager.cpp:20:16: error: ‘NULL’ was not declared in this scope
  gamepadList = NULL;
```

Cheers,
PicoJr.